### PR TITLE
Add Shared Preference Screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,8 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity"/>
         </activity>
+        <activity android:name=".SettingsActivity"
+            android:label="Settings"></activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/jeffkungu/movieapp/SettingsActivity.java
+++ b/app/src/main/java/com/example/jeffkungu/movieapp/SettingsActivity.java
@@ -1,8 +1,26 @@
 package com.example.jeffkungu.movieapp;
 
+import android.os.Bundle;
+import android.preference.PreferenceActivity;
+import android.preference.PreferenceFragment;
+import android.support.annotation.Nullable;
+
 /**
  * Created by Jeffkungu on 10/11/2017.
  */
 
-public class SettingsActivity {
+public class SettingsActivity extends PreferenceActivity{
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getFragmentManager().beginTransaction().replace(android.R.id.content, new SettingsFragment()).commit();
+    }
+
+    public static class SettingsFragment extends PreferenceFragment {
+        @Override
+        public void onCreate(@Nullable Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            addPreferencesFromResource(R.xml.prefrences);
+        }
+    }
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="pref_sort_order">
+        <item>@string/pref_most_popular</item>
+        <item>@string/pref_highest_rated</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="rating">User Rating</string>
     <string name="release">Release Date</string>
     <string name="pref_sort_order_label">Sort Order</string>
+    <string name="pref_sort_order_key">Sort Order Key</string>
     <string name="pref_most_popular">Most Popular</string>
     <string name="pref_highest_rated">Highest Rated</string>
     <string name="title_activity_detail">DetailActivity</string>

--- a/app/src/main/res/xml/prefrences.xml
+++ b/app/src/main/res/xml/prefrences.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <ListPreference
+        android:title="@string/pref_sort_order_label"
+        android:key="@string/pref_sort_order_key"
+        android:defaultValue="@string/pref_most_popular"
+        android:entries="@array/pref_sort_order"
+        android:entryValues="@array/pref_sort_order">
+
+    </ListPreference>
+</PreferenceScreen>


### PR DESCRIPTION
#### What does this PR do?
Adds a new Api call which allows users to get updates on both the popular and top-rated movies.

#### Description of task completed.
Adds a shared preference screen on the UI which allows users to view both popular and top-rated movies.

#### How should this be manually tested?
- After cloning the repo, run the app on an android device using the android studio
- Click on the top right icon which pops up a settings-screen
- Click on settings. It opens a shared preference screen titled sort order.
- Click on the sort order title. I opens a dialog with two options; Most Popular or Highest Rated. Choose either of the two sort order options.
- Go back to the main screen and observe the difference; The movies displayed should be according to the sort order option selected.